### PR TITLE
ci: enable Dependabot for Terraform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+- package-ecosystem: terraform
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
Lets Dependabot check for updates to referenced Terraform modules daily.