### PR TITLE
ci: use correct Terraform version from workflow matrix

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,12 @@ jobs:
         lfs: true
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ matrix.terraform }}
+        terraform_wrapper: false
+
     - name: Install TFLint
       uses: terraform-linters/setup-tflint@v1
       with:

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13, ~> 0.14, ~> 0.15"
+  required_version = ">= 0.13, < 0.16"
 }
 
 module "this" {

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13, < 0.16"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Previously, Terraform 0.15.3 which is installed on GitHub hosted runners was used.