### PR TITLE
ci: fix download of tfsec dependency

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install pre-commit & deps
       run: |
         pip install pre-commit
-        curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
+        curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
 
     - name: Run pre-commit
       run: pre-commit run --color=always --show-diff-on-failure --all-files


### PR DESCRIPTION
tfsec includes a checksum file for every asset. Previous regex would match both the binary and the checksum, giving back two URLs. cURL puked and it didn't work.
