### PR TITLE
fix: prevent Lambda from erroring out if Crawler is already running

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,16 @@ const AWS = require('aws-sdk');
 
 exports.handler = function(event, context, callback) {
     const glue = new AWS.Glue();
+    
     glue.startCrawler({ Name: process.env.CRAWLER_NAME }, function(err, data) {
         if (err) {
-            throw new Error(err);
+            // Check if Crawler is already running
+            const response = JSON.parse(this.httpResponse.body);
+            if (response['__type'] == 'CrawlerRunningException') {
+                console.log('Crawler already running; ignoring trigger.');
+
+                callback(null, response.Message);
+            }
         }
         else {
             console.log("Successfully triggered crawler");


### PR DESCRIPTION
CUR often uploads multiple objects within a short period of time.
This results in the Lamba triggering multiple times, and the Crawler attempted started as many times resulting in an error being thrown.

This PR changes this so it doesn't error out.
