### PR TITLE
fix: prevent conflicting operations on creating S3 resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,8 @@ resource "aws_s3_bucket_policy" "cur" {
 
   bucket = aws_s3_bucket.cur[0].id
   policy = data.aws_iam_policy_document.s3_cur[0].json
+
+  depends_on = [aws_s3_bucket_public_access_block.cur]
 }
 
 data "aws_iam_policy_document" "s3_cur" {

--- a/notifications.tf
+++ b/notifications.tf
@@ -17,6 +17,7 @@ resource "aws_s3_bucket_notification" "cur" {
   depends_on = [
     aws_s3_bucket.cur,
     aws_lambda_permission.allow_bucket,
+    aws_s3_bucket_policy.cur,
   ]
 }
 


### PR DESCRIPTION
This fixes a race condition when applying several actions on the same S3 bucket.
In this case bucket policy and S3 notifications.
