### PR TITLE
fix: prevent KMS data source from being read during apply

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install pre-commit & deps
       run: |
         pip install pre-commit
-        curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
+        curl -L "$(curl -Ls https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
 
     - name: Run pre-commit
       run: pre-commit run --color=always --show-diff-on-failure --all-files

--- a/glue.tf
+++ b/glue.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "crawler" {
       "kms:Encrypt",
     ]
 
-    resources = [data.aws_kms_key.s3.arn]
+    resources = [var.s3_use_existing_kms_key ? data.aws_kms_key.s3[0].arn : aws_kms_key.s3[0].arn]
   }
 
   statement {


### PR DESCRIPTION
Previously `data.aws_kms_key.s3` was used to read _both_ the existing KMS key (if chosen) and the newly created KMS key.

This required a `depends_on` on the data source, which forced it to always be read during apply instead of refresh, leading to unpredictable plans.
