### PR TITLE
feat: create QuickSight Data Sets and CUDOS dashboard

### DIFF
--- a/athena.tf
+++ b/athena.tf
@@ -1,0 +1,19 @@
+locals {
+  athena_views = toset([
+    "compute_savings_plan_eligible_spend_sp_ri.sql",
+    "ec2_running_cost_sp_ri.sql",
+    "ri_sp_mapping_sp_ri.sql",
+    "s3_sp_ri.sql",
+    "summary_view_sp_ri.sql",
+  ])
+}
+
+resource "local_file" "compute_savings_plans" {
+  for_each = local.athena_views
+
+  content = templatefile("${path.module}/views/${each.key}", {
+    athena_cur_table_name = aws_glue_catalog_database.cur.name
+  })
+  filename        = "${path.module}/.generated/${each.key}"
+  file_permission = "0600"
+}

--- a/athena.tf
+++ b/athena.tf
@@ -1,19 +1,40 @@
 locals {
-  athena_views = toset([
-    "compute_savings_plan_eligible_spend_sp_ri.sql",
-    "ec2_running_cost_sp_ri.sql",
-    "ri_sp_mapping_sp_ri.sql",
-    "s3_sp_ri.sql",
-    "summary_view_sp_ri.sql",
+  # View templates for Athena. Fetched from:
+  # https://github.com/aws-samples/aws-cudos-framework-deployment/tree/3a1b408a71f0ed36fbda4094c2428b561ecfbaa7/cudos/view-templates
+  athena_view_template_paths = toset([
+    "views/compute_savings_plan_eligible_spend_sp_ri.sql",
+    "views/ec2_running_cost_sp_ri.sql",
+    "views/ri_sp_mapping_sp_ri.sql",
+    "views/s3_sp_ri.sql",
+    "views/summary_view_sp_ri.sql",
+    "views/account_map.sql",
   ])
 }
 
-resource "local_file" "compute_savings_plans" {
-  for_each = local.athena_views
+resource "local_file" "athena_views" {
+  for_each = local.athena_view_template_paths
 
-  content = templatefile("${path.module}/views/${each.key}", {
-    athena_cur_table_name = aws_glue_catalog_database.cur.name
+  content = templatefile("${path.module}/${each.key}", {
+    athena_cur_table_name = var.glue_destination_table
   })
+
   filename        = "${path.module}/.generated/${each.key}"
   file_permission = "0600"
+}
+
+resource "null_resource" "athena_views" {
+  for_each = local.athena_view_template_paths
+
+  triggers = {
+    checksum = filesha256(each.key)
+  }
+
+  provisioner "local-exec" {
+    command = join(" ", [
+      "aws athena start-query-execution",
+      "--query-execution-context Database=${aws_glue_catalog_database.cur.name},Catalog=AwsDataCatalog",
+      "--work-group primary --query-string \"file://${local_file.athena_views[each.key].filename}\"",
+      "--region ${data.aws_region.current.name}",
+    ])
+  }
 }

--- a/dashboards/cudos.json
+++ b/dashboards/cudos.json
@@ -1,0 +1,53 @@
+{
+  "AwsAccountId": "${awsAccountId}",
+  "DashboardId": "${dashboardId}",
+  "Name": "CUDOS Dashboard",
+  "Permissions": [
+    {
+      "Principal": "${user_arn}",
+      "Actions": [
+        "quicksight:DescribeDashboard",
+        "quicksight:ListDashboardVersions",
+        "quicksight:UpdateDashboardPermissions",
+        "quicksight:QueryDashboard",
+        "quicksight:UpdateDashboard",
+        "quicksight:DeleteDashboard",
+        "quicksight:DescribeDashboardPermissions",
+        "quicksight:UpdateDashboardPublishedVersion"
+      ]
+    }
+  ],
+  "DashboardPublishOptions": {
+    "AdHocFilteringOption": {
+      "AvailabilityStatus": "DISABLED"
+    }
+  },
+  "SourceEntity": {
+    "SourceTemplate": {
+      "DataSetReferences": [
+        {
+          "DataSetPlaceholder": "summary_view",
+          "DataSetArn": "arn:aws:quicksight:${region}:${awsAccountId}:dataset/d01a936f-2b8f-49dd-8f95-d9c7130c5e46"
+        },
+        {
+          "DataSetPlaceholder": "ec2_running_cost",
+          "DataSetArn": "arn:aws:quicksight:${region}:${awsAccountId}:dataset/9497cc49-c9b1-4dcd-8bcc-c16396898f29"
+        },
+        {
+          "DataSetPlaceholder": "compute_savings_plan_eligible_spend",
+          "DataSetArn": "arn:aws:quicksight:${region}:${awsAccountId}:dataset/3fa0d804-9bf5-4a20-a61d-4bdbb6d543b1"
+        },
+        {
+          "DataSetPlaceholder": "s3_view",
+          "DataSetArn": "arn:aws:quicksight:${region}:${awsAccountId}:dataset/826896be-4d0f-4f90-832f-3427f5444016"
+        },
+        {
+          "DataSetPlaceholder": "customer_all",
+          "DataSetArn": "arn:aws:quicksight:${region}:${awsAccountId}:dataset/595c66b7-08b6-46ad-87ed-b74fe34dd333"
+        }
+      ],
+      "Arn": "arn:aws:quicksight:us-east-1:${sourceAccountId}:template/${sourceTemplateId}"
+    }
+  },
+  "VersionDescription": "1"
+}

--- a/data-sets/compute_savings_plan_eligible_spend.json
+++ b/data-sets/compute_savings_plan_eligible_spend.json
@@ -1,0 +1,122 @@
+{
+    "DataSetId": "3fa0d804-9bf5-4a20-a61d-4bdbb6d543b1",
+    "Name": "cudos_compute_savings_plan_eligible_spend",
+    "PhysicalTableMap": {
+        "5939aadd-602d-4127-8974-b4ff911eb6c4": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "compute_savings_plan_eligible_spend",
+                "InputColumns": [
+                    {
+                        "Name": "billing_period",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "month",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "year",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "payer_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "unblended_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "linked_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_date",
+                        "Type": "DATETIME"
+                    }
+                ]
+            }
+        },
+        "a073386e-83e3-4798-8167-5f5604e48ede": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "account_map",
+                "InputColumns": [
+                    {
+                        "Name": "account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "account_name",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        }
+    },
+    "LogicalTableMap": {
+        "606cb37c-c311-4cbd-96e4-e0b7ac252d3e": {
+            "Alias": "Intermediate Table",
+            "DataTransforms": [
+                {
+                    "ProjectOperation": {
+                        "ProjectedColumns": [
+                            "year",
+                            "month",
+                            "payer_account_id",
+                            "linked_account_id",
+                            "billing_period",
+                            "usage_date",
+                            "unblended_cost",
+                            "account_id",
+                            "account_name"
+                        ]
+                    }
+                }
+            ],
+            "Source": {
+                "JoinInstruction": {
+                    "LeftOperand": "d8ff07f9-bc56-4b6d-9388-f9e2cdd74d78",
+                    "RightOperand": "7d72d7c7-85ae-4349-8b61-610af5393caf",
+                    "Type": "LEFT",
+                    "OnClause": "{linked_account_id} = {account_id}"
+                }
+            }
+        },
+        "7d72d7c7-85ae-4349-8b61-610af5393caf": {
+            "Alias": "account_map",
+            "Source": {
+                "PhysicalTableId": "a073386e-83e3-4798-8167-5f5604e48ede"
+            }
+        },
+        "d8ff07f9-bc56-4b6d-9388-f9e2cdd74d78": {
+            "Alias": "compute_savings_plan_eligible_spend",
+            "Source": {
+                "PhysicalTableId": "5939aadd-602d-4127-8974-b4ff911eb6c4"
+            }
+        }
+    },
+    "ImportMode": "SPICE",
+    "Permissions": [
+        {
+            "Principal": "${user_arn}",
+            "Actions": [
+                "quicksight:UpdateDataSetPermissions",
+                "quicksight:DescribeDataSet",
+                "quicksight:DescribeDataSetPermissions",
+                "quicksight:PassDataSet",
+                "quicksight:DescribeIngestion",
+                "quicksight:ListIngestions",
+                "quicksight:UpdateDataSet",
+                "quicksight:DeleteDataSet",
+                "quicksight:CreateIngestion",
+                "quicksight:CancelIngestion"
+            ]
+        }
+    ]
+}

--- a/data-sets/cur.json
+++ b/data-sets/cur.json
@@ -1,0 +1,1187 @@
+{
+    "DataSetId": "595c66b7-08b6-46ad-87ed-b74fe34dd333",
+    "Name": "cudos_cur",
+    "PhysicalTableMap": {
+        "6e0cf97c-e45a-4824-939f-98d27612efb5": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "account_map",
+                "InputColumns": [
+                    {
+                        "Name": "account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "account_name",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        },
+        "b163ad4b-f459-4b01-b2f3-54a168088640": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "${athena_cur_table_name}",
+                "InputColumns": [
+                    {
+                        "Name": "product_updates",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_aws_ec2spot_fleet_request_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_application_department",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "year",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "bill_billing_period_end_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "product_enhanced_networking_supported",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_maximum_storage_volume",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_operating_system",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_storage",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_workload_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_content_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_finding_storage",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_line_item_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_amortized_upfront_fee_for_billing_period",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "line_item_normalization_factor",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "reservation_start_time",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_maximum_extended_storage",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "savings_plan_used_commitment",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "line_item_blended_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_free_trial",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_input_mode",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_gpu",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_physical_processor",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_workload",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_directory_type_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_from_location",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_product_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_describes",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_memory",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_aws_created_by",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_capacitystatus",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_bundle_group",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_recurring_fee_for_usage",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_normalization_size_factor",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_public_on_demand_rate",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_resource_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_lease_contract_length",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_origin",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_legal_entity",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_directory_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_deployment_option",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_resource_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_application_cost_center",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_category",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_edition",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_directory_size",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_tax_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_instance_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_storage_class",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_standard_storage_retention_included",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_dominantnondominant",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_datatransferout",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_compute_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_physical_cpu",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_ops_items",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_effective_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_volume_api_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_fee_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_request_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_database_engine",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "savings_plan_savings_plan_a_r_n",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_queue_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_software_included",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_application",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_request_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_availability_zone",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "bill_billing_entity",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "month",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_bundle_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_usage_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_processor_features",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_vcpu",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_enhanced_networking_support",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_component",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_region",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_finding_source",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_usage_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_intel_avx_available",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_dedicated_ebs_throughput",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_standard_storage",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_sku",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_free_usage_included",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_max_iopsvolume",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "identity_line_item_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_routing_target",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_line_item_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_total_reserved_units",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_group",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_department",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_currency_code",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_servicename",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_term",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "savings_plan_amortized_upfront_commitment_for_billing_period",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "savings_plan_savings_plan_effective_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "reservation_end_time",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "cost_category_demo",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_owner",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_client_location",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_max_throughputvolume",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_memory_gib",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_to_location",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_unused_quantity",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "resource_tags_aws_autoscaling_group_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_granularity",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_ratetype",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_clock_speed",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_public_on_demand_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "reservation_normalized_units_per_reservation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_instances",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_broker_engine",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_product_family",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_availability_zone",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_processor_architecture",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_blended_rate",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_rootvolume",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_endpoint_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_routing_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_rate_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_max_iops_burst_performance",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_transfer_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_fee_code",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_upfront_value",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "resource_tags_user_environment",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_gpu_memory",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_operation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_unblended_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "reservation_number_of_reservations",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "savings_plan_savings_plan_rate",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "bill_payer_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_memorytype",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_logs_destination",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_unused_amortized_upfront_fee_for_billing_period",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_pricing_unit",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_network_performance",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_servicecode",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_group_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_steps",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_modification_status",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_total_reserved_normalized_units",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_application_owner",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_compute_family",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_message_delivery_frequency",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_intel_turbo_available",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_unused_normalized_unit_quantity",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "cost_category_env",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_unused_recurring_fee",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_traffic_direction",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_availability",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_ecu",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_insightstype",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_gets",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_intel_avx2_available",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_units_per_reservation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_purchase_option",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_amortized_upfront_cost_for_usage",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "line_item_usage_amount",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_instance_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_standard_group",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_event_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_usage_end_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "product_pre_installed_sw",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_alarm_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_location",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_current_generation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "savings_plan_total_commitment_to_date",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "resource_tags_user_cost_center",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "bill_bill_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_output_mode",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "cost_category_team",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "bill_billing_period_start_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "product_operation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_max_volume_size",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_running_mode",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_normalized_usage_amount",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_license",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "savings_plan_recurring_commitment_for_billing_period",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "line_item_usage_start_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "product_physical_gpu",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_instance_family",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_instance",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_engine_code",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "bill_invoice_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_storage_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_recipient",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_storage_media",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "identity_time_interval",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_cache_engine",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_volume_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_offering_class",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_provisioned",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_license_model",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_instance_type_family",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_product_code",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_location_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_usagetype",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_subscription_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "line_item_unblended_rate",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_bundle",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_message_delivery_order",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_subscription_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_cputype",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_durability",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "reservation_reservation_a_r_n",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_uservolume",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_from_location_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_to_location_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_version",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_currency",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_minimum_storage_volume",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_tenancy",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_finding_group",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_min_volume_size",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_tags_user_application_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_free_query_types",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_unit",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        }
+    },
+    "LogicalTableMap": {
+        "0628f91f-8d1b-4936-b141-f2cd828af18e": {
+            "Alias": "account_map",
+            "Source": {
+                "PhysicalTableId": "6e0cf97c-e45a-4824-939f-98d27612efb5"
+            }
+        },
+        "2f69dc70-9487-4f34-9120-e5f40660b257": {
+            "Alias": "${athena_cur_table_name}",
+            "Source": {
+                "PhysicalTableId": "b163ad4b-f459-4b01-b2f3-54a168088640"
+            }
+        },
+        "faad660a-8f70-4660-af84-8ab3c8a9474f": {
+            "Alias": "Intermediate Table",
+            "DataTransforms": [
+                {
+                    "ProjectOperation": {
+                        "ProjectedColumns": [
+                            "identity_line_item_id",
+                            "identity_time_interval",
+                            "bill_invoice_id",
+                            "bill_billing_entity",
+                            "bill_bill_type",
+                            "bill_payer_account_id",
+                            "bill_billing_period_start_date",
+                            "bill_billing_period_end_date",
+                            "line_item_usage_account_id",
+                            "line_item_line_item_type",
+                            "line_item_usage_start_date",
+                            "line_item_usage_end_date",
+                            "line_item_product_code",
+                            "line_item_usage_type",
+                            "line_item_operation",
+                            "line_item_availability_zone",
+                            "line_item_resource_id",
+                            "line_item_usage_amount",
+                            "line_item_normalization_factor",
+                            "line_item_normalized_usage_amount",
+                            "line_item_currency_code",
+                            "line_item_unblended_rate",
+                            "line_item_unblended_cost",
+                            "line_item_blended_rate",
+                            "line_item_blended_cost",
+                            "line_item_line_item_description",
+                            "line_item_tax_type",
+                            "line_item_legal_entity",
+                            "product_product_name",
+                            "product_availability",
+                            "product_capacitystatus",
+                            "product_clock_speed",
+                            "product_current_generation",
+                            "product_database_engine",
+                            "product_dedicated_ebs_throughput",
+                            "product_deployment_option",
+                            "product_description",
+                            "product_durability",
+                            "product_ecu",
+                            "product_edition",
+                            "product_engine_code",
+                            "product_enhanced_networking_supported",
+                            "product_event_type",
+                            "product_free_query_types",
+                            "product_from_location",
+                            "product_from_location_type",
+                            "product_group",
+                            "product_group_description",
+                            "product_instance_family",
+                            "product_instance_type",
+                            "product_instance_type_family",
+                            "product_license_model",
+                            "product_location",
+                            "product_location_type",
+                            "product_max_iops_burst_performance",
+                            "product_max_iopsvolume",
+                            "product_max_throughputvolume",
+                            "product_max_volume_size",
+                            "product_memory",
+                            "product_message_delivery_frequency",
+                            "product_message_delivery_order",
+                            "product_min_volume_size",
+                            "product_network_performance",
+                            "product_normalization_size_factor",
+                            "product_operating_system",
+                            "product_operation",
+                            "product_physical_processor",
+                            "product_pre_installed_sw",
+                            "product_processor_architecture",
+                            "product_processor_features",
+                            "product_product_family",
+                            "product_queue_type",
+                            "product_region",
+                            "product_servicecode",
+                            "product_servicename",
+                            "product_sku",
+                            "product_storage",
+                            "product_storage_class",
+                            "product_storage_media",
+                            "product_subscription_type",
+                            "product_tenancy",
+                            "product_to_location",
+                            "product_to_location_type",
+                            "product_transfer_type",
+                            "product_usagetype",
+                            "product_vcpu",
+                            "product_version",
+                            "product_volume_type",
+                            "pricing_lease_contract_length",
+                            "pricing_offering_class",
+                            "pricing_purchase_option",
+                            "pricing_rate_id",
+                            "pricing_public_on_demand_cost",
+                            "pricing_public_on_demand_rate",
+                            "pricing_term",
+                            "pricing_unit",
+                            "reservation_amortized_upfront_cost_for_usage",
+                            "reservation_amortized_upfront_fee_for_billing_period",
+                            "reservation_effective_cost",
+                            "reservation_end_time",
+                            "reservation_modification_status",
+                            "reservation_normalized_units_per_reservation",
+                            "reservation_number_of_reservations",
+                            "reservation_recurring_fee_for_usage",
+                            "reservation_reservation_a_r_n",
+                            "reservation_start_time",
+                            "reservation_subscription_id",
+                            "reservation_total_reserved_normalized_units",
+                            "reservation_total_reserved_units",
+                            "reservation_units_per_reservation",
+                            "reservation_unused_amortized_upfront_fee_for_billing_period",
+                            "reservation_unused_normalized_unit_quantity",
+                            "reservation_unused_quantity",
+                            "reservation_unused_recurring_fee",
+                            "reservation_upfront_value",
+                            "resource_tags_aws_autoscaling_group_name",
+                            "resource_tags_aws_created_by",
+                            "resource_tags_aws_ec2spot_fleet_request_id",
+                            "resource_tags_user_cost_center",
+                            "resource_tags_user_department",
+                            "resource_tags_user_environment",
+                            "resource_tags_user_name",
+                            "resource_tags_user_workload",
+                            "resource_tags_user_workload_type",
+                            "product_alarm_type",
+                            "product_compute_family",
+                            "product_compute_type",
+                            "product_content_type",
+                            "product_cputype",
+                            "product_intel_avx2_available",
+                            "product_intel_avx_available",
+                            "product_intel_turbo_available",
+                            "product_maximum_extended_storage",
+                            "product_memory_gib",
+                            "product_memorytype",
+                            "product_origin",
+                            "product_recipient",
+                            "product_routing_target",
+                            "product_routing_type",
+                            "product_standard_storage_retention_included",
+                            "product_volume_api_name",
+                            "savings_plan_total_commitment_to_date",
+                            "savings_plan_savings_plan_a_r_n",
+                            "savings_plan_savings_plan_rate",
+                            "savings_plan_used_commitment",
+                            "savings_plan_savings_plan_effective_cost",
+                            "savings_plan_amortized_upfront_commitment_for_billing_period",
+                            "savings_plan_recurring_commitment_for_billing_period",
+                            "product_availability_zone",
+                            "product_broker_engine",
+                            "product_bundle",
+                            "product_bundle_description",
+                            "product_bundle_group",
+                            "product_category",
+                            "product_client_location",
+                            "product_component",
+                            "product_datatransferout",
+                            "product_directory_size",
+                            "product_directory_type",
+                            "product_directory_type_description",
+                            "product_dominantnondominant",
+                            "product_endpoint_type",
+                            "product_enhanced_networking_support",
+                            "product_fee_description",
+                            "product_finding_group",
+                            "product_finding_source",
+                            "product_finding_storage",
+                            "product_free_trial",
+                            "product_free_usage_included",
+                            "product_gpu",
+                            "product_gpu_memory",
+                            "product_granularity",
+                            "product_insightstype",
+                            "product_instance_name",
+                            "product_license",
+                            "product_logs_destination",
+                            "product_maximum_storage_volume",
+                            "product_minimum_storage_volume",
+                            "product_physical_cpu",
+                            "product_physical_gpu",
+                            "product_pricing_unit",
+                            "product_provisioned",
+                            "product_ratetype",
+                            "product_resource_type",
+                            "product_rootvolume",
+                            "product_running_mode",
+                            "product_software_included",
+                            "product_standard_group",
+                            "product_standard_storage",
+                            "product_steps",
+                            "product_storage_type",
+                            "product_traffic_direction",
+                            "product_type",
+                            "product_uservolume",
+                            "pricing_currency",
+                            "resource_tags_user_application_department",
+                            "resource_tags_user_application",
+                            "cost_category_demo",
+                            "cost_category_env",
+                            "cost_category_team",
+                            "product_cache_engine",
+                            "product_describes",
+                            "product_gets",
+                            "product_ops_items",
+                            "product_updates",
+                            "resource_tags_user_owner",
+                            "resource_tags_user_application_cost_center",
+                            "resource_tags_user_application_name",
+                            "resource_tags_user_application_owner",
+                            "product_instances",
+                            "product_request_description",
+                            "product_request_type",
+                            "product_input_mode",
+                            "product_output_mode",
+                            "product_instance",
+                            "product_fee_code",
+                            "year",
+                            "month",
+                            "account_id",
+                            "account_name"
+                        ]
+                    }
+                },
+                {
+                    "TagColumnOperation": {
+                        "ColumnName": "product_region",
+                        "Tags": [
+                            {
+                                "ColumnGeographicRole": "STATE"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "Source": {
+                "JoinInstruction": {
+                    "LeftOperand": "2f69dc70-9487-4f34-9120-e5f40660b257",
+                    "RightOperand": "0628f91f-8d1b-4936-b141-f2cd828af18e",
+                    "Type": "LEFT",
+                    "OnClause": "{line_item_usage_account_id} = {account_id}"
+                }
+            }
+        }
+    },
+    "ImportMode": "DIRECT_QUERY",
+    "Permissions": [
+        {
+            "Principal": "${user_arn}",
+            "Actions": [
+                "quicksight:UpdateDataSetPermissions",
+                "quicksight:DescribeDataSet",
+                "quicksight:DescribeDataSetPermissions",
+                "quicksight:PassDataSet",
+                "quicksight:DescribeIngestion",
+                "quicksight:ListIngestions",
+                "quicksight:UpdateDataSet",
+                "quicksight:DeleteDataSet",
+                "quicksight:CreateIngestion",
+                "quicksight:CancelIngestion"
+            ]
+        }
+    ]
+}

--- a/data-sets/data-source.json
+++ b/data-sets/data-source.json
@@ -1,0 +1,27 @@
+{
+        "DataSourceId": "95aa6f18-abb4-436f-855f-182b199a961f",
+        "Name": "cudos_athena_datasource",
+        "Type": "ATHENA",
+        "DataSourceParameters": {
+            "AthenaParameters": {
+                "WorkGroup": "primary"
+            }
+        },
+        "SslProperties": {
+            "DisableSsl": false
+        },
+        "Permissions": [
+            {
+                "Principal": "${user_arn}",
+                "Actions": [
+                    "quicksight:UpdateDataSourcePermissions",
+                    "quicksight:DescribeDataSource",
+                    "quicksight:DescribeDataSourcePermissions",
+                    "quicksight:PassDataSource",
+                    "quicksight:UpdateDataSource",
+                    "quicksight:DeleteDataSource"
+                ]
+            }
+        ]
+
+}

--- a/data-sets/ec2_running_cost.json
+++ b/data-sets/ec2_running_cost.json
@@ -1,0 +1,132 @@
+{
+    "DataSetId": "9497cc49-c9b1-4dcd-8bcc-c16396898f29",
+    "Name": "cudos_ec2_running_cost",
+    "PhysicalTableMap": {
+        "9db232e0-a43d-4885-b122-6349618551b6": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "account_map",
+                "InputColumns": [
+                    {
+                        "Name": "account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "account_name",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        },
+        "f664fb78-28ab-4119-a0f5-809a3f0b4d72": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "ec2_running_cost",
+                "InputColumns": [
+                    {
+                        "Name": "billing_period",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "purchase_option",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "month",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "year",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "payer_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "linked_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "amortized_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "usage_quantity",
+                        "Type": "DECIMAL"
+                    }
+                ]
+            }
+        }
+    },
+    "LogicalTableMap": {
+        "0214ccfd-faf3-4d5f-b334-3171555ecba3": {
+            "Alias": "Intermediate Table",
+            "DataTransforms": [
+                {
+                    "ProjectOperation": {
+                        "ProjectedColumns": [
+                            "year",
+                            "month",
+                            "billing_period",
+                            "usage_date",
+                            "payer_account_id",
+                            "linked_account_id",
+                            "purchase_option",
+                            "amortized_cost",
+                            "usage_quantity",
+                            "account_id",
+                            "account_name"
+                        ]
+                    }
+                }
+            ],
+            "Source": {
+                "JoinInstruction": {
+                    "LeftOperand": "8f4dd082-917c-4e44-9b7c-57bc6bb33ebe",
+                    "RightOperand": "d1a3a9a4-0569-457f-bd14-9bd53ea96eb8",
+                    "Type": "LEFT",
+                    "OnClause": "{payer_account_id} = {account_id}"
+                }
+            }
+        },
+        "8f4dd082-917c-4e44-9b7c-57bc6bb33ebe": {
+            "Alias": "ec2_running_cost",
+            "Source": {
+                "PhysicalTableId": "f664fb78-28ab-4119-a0f5-809a3f0b4d72"
+            }
+        },
+        "d1a3a9a4-0569-457f-bd14-9bd53ea96eb8": {
+            "Alias": "account_map",
+            "Source": {
+                "PhysicalTableId": "9db232e0-a43d-4885-b122-6349618551b6"
+            }
+        }
+    },
+    "ImportMode": "SPICE",
+    "Permissions": [
+        {
+            "Principal": "${user_arn}",
+            "Actions": [
+                "quicksight:UpdateDataSetPermissions",
+                "quicksight:DescribeDataSet",
+                "quicksight:DescribeDataSetPermissions",
+                "quicksight:PassDataSet",
+                "quicksight:DescribeIngestion",
+                "quicksight:ListIngestions",
+                "quicksight:UpdateDataSet",
+                "quicksight:DeleteDataSet",
+                "quicksight:CreateIngestion",
+                "quicksight:CancelIngestion"
+            ]
+        }
+    ]
+}

--- a/data-sets/s3_view.json
+++ b/data-sets/s3_view.json
@@ -1,0 +1,172 @@
+{
+    "DataSetId": "826896be-4d0f-4f90-832f-3427f5444016",
+    "Name": "cudos_s3_view",
+    "PhysicalTableMap": {
+        "516bd20f-660c-49e0-95d3-0b5d21ef39f7": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "account_map",
+                "InputColumns": [
+                    {
+                        "Name": "account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "account_name",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        },
+        "7bb99428-5dfd-4599-8893-b4f57f0c689f": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "s3_view",
+                "InputColumns": [
+                    {
+                        "Name": "billing_period",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "charge_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "year",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "payer_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "product_code",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "month",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "public_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "unblended_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "linked_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_quantity",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "region",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "operation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_unit",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        }
+    },
+    "LogicalTableMap": {
+        "4559aa95-4a54-4998-800b-5fd03af260ea": {
+            "Alias": "account_map",
+            "Source": {
+                "PhysicalTableId": "516bd20f-660c-49e0-95d3-0b5d21ef39f7"
+            }
+        },
+        "6beb277c-4d74-47da-b425-1e255aa31be6": {
+            "Alias": "Intermediate Table",
+            "DataTransforms": [
+                {
+                    "ProjectOperation": {
+                        "ProjectedColumns": [
+                            "year",
+                            "month",
+                            "billing_period",
+                            "usage_date",
+                            "payer_account_id",
+                            "linked_account_id",
+                            "resource_id",
+                            "product_code",
+                            "operation",
+                            "region",
+                            "charge_type",
+                            "pricing_unit",
+                            "usage_quantity",
+                            "unblended_cost",
+                            "public_cost",
+                            "account_id",
+                            "account_name"
+                        ]
+                    }
+                },
+                {
+                    "TagColumnOperation": {
+                        "ColumnName": "region",
+                        "Tags": [
+                            {
+                                "ColumnGeographicRole": "STATE"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "Source": {
+                "JoinInstruction": {
+                    "LeftOperand": "ea0d1482-1bf2-46ee-8dc4-5aaea2ab2209",
+                    "RightOperand": "4559aa95-4a54-4998-800b-5fd03af260ea",
+                    "Type": "LEFT",
+                    "OnClause": "{linked_account_id} = {account_id}"
+                }
+            }
+        },
+        "ea0d1482-1bf2-46ee-8dc4-5aaea2ab2209": {
+            "Alias": "s3_view",
+            "Source": {
+                "PhysicalTableId": "7bb99428-5dfd-4599-8893-b4f57f0c689f"
+            }
+        }
+    },
+    "ImportMode": "SPICE",
+    "Permissions": [
+        {
+            "Principal": "${user_arn}",
+            "Actions": [
+                "quicksight:UpdateDataSetPermissions",
+                "quicksight:DescribeDataSet",
+                "quicksight:DescribeDataSetPermissions",
+                "quicksight:PassDataSet",
+                "quicksight:DescribeIngestion",
+                "quicksight:ListIngestions",
+                "quicksight:UpdateDataSet",
+                "quicksight:DeleteDataSet",
+                "quicksight:CreateIngestion",
+                "quicksight:CancelIngestion"
+            ]
+        }
+    ]
+}

--- a/data-sets/summary_view.json
+++ b/data-sets/summary_view.json
@@ -1,0 +1,364 @@
+{
+    "DataSetId": "d01a936f-2b8f-49dd-8f95-d9c7130c5e46",
+    "Name": "cudos_summary_view",
+    "PhysicalTableMap": {
+        "ae9f61a5-d48a-42ed-8b9c-e9f87a9f37fa": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "summary_view",
+                "InputColumns": [
+                    {
+                        "Name": "billing_period",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "purchase_option",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_to_location",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "charge_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "current_generation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "year",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "payer_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_from_location",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_date",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "ri_sp_trueup",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "amortized_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "product_code",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "platform",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "linked_account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "invoice_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "ri_sp_arn",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "legal_entity",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_group",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "ri_sp_upfront_fees",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "processor_features",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_family",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "availability_zone",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "billing_entity",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "tenancy",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "database_engine",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "product_name",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "processor",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "instance_type_family",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "charge_category",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "month",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "resource_id_count",
+                        "Type": "INTEGER"
+                    },
+                    {
+                        "Name": "public_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "unblended_cost",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "service",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "usage_quantity",
+                        "Type": "DECIMAL"
+                    },
+                    {
+                        "Name": "item_description",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "region",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "operation",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "instance_type",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "pricing_unit",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        },
+        "c0420538-7a33-4234-af0f-697600127f78": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "account_map",
+                "InputColumns": [
+                    {
+                        "Name": "account_id",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "account_name",
+                        "Type": "STRING"
+                    }
+                ]
+            }
+        },
+        "f756ee81-056c-4b8d-8bdb-fbce0eff48ba": {
+            "RelationalTable": {
+                "DataSourceArn": "arn:aws:quicksight:${region}:${account}:datasource/95aa6f18-abb4-436f-855f-182b199a961f",
+                "Catalog": "AwsDataCatalog",
+                "Schema": "${athena_database_name}",
+                "Name": "ri_sp_mapping",
+                "InputColumns": [
+                    {
+                        "Name": "ri_sp_offering",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "payer_account_id_mapping",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "ri_sp_payment",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "billing_period_mapping",
+                        "Type": "DATETIME"
+                    },
+                    {
+                        "Name": "ri_sp_arn_mapping",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "ri_sp_term",
+                        "Type": "STRING"
+                    },
+                    {
+                        "Name": "ri_sp_end_date",
+                        "Type": "DATETIME"
+                    }
+                ]
+            }
+        }
+    },
+    "LogicalTableMap": {
+        "51531464-4b4b-4d8c-b511-96ea6955c085": {
+            "Alias": "Intermediate Table (2)",
+            "DataTransforms": [
+                {
+                    "ProjectOperation": {
+                        "ProjectedColumns": [
+                            "year",
+                            "month",
+                            "billing_period",
+                            "usage_date",
+                            "payer_account_id",
+                            "linked_account_id",
+                            "invoice_id",
+                            "charge_type",
+                            "charge_category",
+                            "purchase_option",
+                            "ri_sp_arn",
+                            "product_code",
+                            "product_name",
+                            "service",
+                            "product_family",
+                            "usage_type",
+                            "operation",
+                            "item_description",
+                            "availability_zone",
+                            "region",
+                            "instance_type_family",
+                            "instance_type",
+                            "platform",
+                            "tenancy",
+                            "processor",
+                            "processor_features",
+                            "database_engine",
+                            "product_group",
+                            "product_from_location",
+                            "product_to_location",
+                            "current_generation",
+                            "legal_entity",
+                            "billing_entity",
+                            "pricing_unit",
+                            "resource_id_count",
+                            "usage_quantity",
+                            "unblended_cost",
+                            "amortized_cost",
+                            "ri_sp_trueup",
+                            "ri_sp_upfront_fees",
+                            "public_cost",
+                            "billing_period_mapping",
+                            "payer_account_id_mapping",
+                            "ri_sp_arn_mapping",
+                            "ri_sp_end_date",
+                            "ri_sp_term",
+                            "ri_sp_offering",
+                            "ri_sp_payment",
+                            "account_id",
+                            "account_name"
+                        ]
+                    }
+                },
+                {
+                    "TagColumnOperation": {
+                        "ColumnName": "region",
+                        "Tags": [
+                            {
+                                "ColumnGeographicRole": "STATE"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "Source": {
+                "JoinInstruction": {
+                    "LeftOperand": "7d020d65-42ca-4372-a64e-a98a4d104267",
+                    "RightOperand": "d1f4ffc2-73e3-425a-b5fe-40fc44c89555",
+                    "Type": "LEFT",
+                    "OnClause": "{linked_account_id} = {account_id}"
+                }
+            }
+        },
+        "736681fc-66e6-4652-833a-acbae2a1c73b": {
+            "Alias": "ri_sp_mapping",
+            "Source": {
+                "PhysicalTableId": "f756ee81-056c-4b8d-8bdb-fbce0eff48ba"
+            }
+        },
+        "7d020d65-42ca-4372-a64e-a98a4d104267": {
+            "Alias": "Intermediate Table",
+            "Source": {
+                "JoinInstruction": {
+                    "LeftOperand": "f211f5c0-a896-4932-80a0-73cd7f0e2ac8",
+                    "RightOperand": "736681fc-66e6-4652-833a-acbae2a1c73b",
+                    "Type": "LEFT",
+                    "OnClause": "{billing_period} = {billing_period_mapping} AND {payer_account_id} = {payer_account_id_mapping} AND {ri_sp_arn} = {ri_sp_arn_mapping}"
+                }
+            }
+        },
+        "d1f4ffc2-73e3-425a-b5fe-40fc44c89555": {
+            "Alias": "account_map",
+            "Source": {
+                "PhysicalTableId": "c0420538-7a33-4234-af0f-697600127f78"
+            }
+        },
+        "f211f5c0-a896-4932-80a0-73cd7f0e2ac8": {
+            "Alias": "summary_view",
+            "Source": {
+                "PhysicalTableId": "ae9f61a5-d48a-42ed-8b9c-e9f87a9f37fa"
+            }
+        }
+    },
+    "ImportMode": "SPICE",
+    "Permissions": [
+        {
+            "Principal": "${user_arn}",
+            "Actions": [
+                "quicksight:UpdateDataSetPermissions",
+                "quicksight:DescribeDataSet",
+                "quicksight:DescribeDataSetPermissions",
+                "quicksight:PassDataSet",
+                "quicksight:DescribeIngestion",
+                "quicksight:ListIngestions",
+                "quicksight:UpdateDataSet",
+                "quicksight:DeleteDataSet",
+                "quicksight:CreateIngestion",
+                "quicksight:CancelIngestion"
+            ]
+        }
+    ]
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,4 +22,8 @@ module "this" {
   report_format      = "Parquet"
   report_compression = "Parquet"
   report_versioning  = "OVERWRITE_REPORT"
+
+  glue_destination_table = "nuuday_hourly"
+  
+  quicksight_user_arn = "arn:aws:quicksight:eu-central-1:985196426381:user/default/quicksight-admin/foo"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -11,6 +11,11 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.0"
     }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -16,6 +16,11 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.0"
     }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
   }
 }
 

--- a/quicksight.tf
+++ b/quicksight.tf
@@ -1,0 +1,98 @@
+locals {
+  # Data set templates for QuickSight. Fetched from:
+  # https://github.com/aws-samples/aws-cudos-framework-deployment/tree/3a1b408a71f0ed36fbda4094c2428b561ecfbaa7/cudos/dataset-templates
+  quicksight_dataset_template_paths = toset([
+    "data-sets/summary_view.json",
+    "data-sets/s3_view.json",
+    "data-sets/ec2_running_cost.json",
+    "data-sets/cur.json",
+    "data-sets/compute_savings_plan_eligible_spend.json",
+  ])
+}
+
+resource "local_file" "quicksight_data_source" {
+  content = templatefile("${path.module}/data-sets/data-source.json", {
+    user_arn = var.quicksight_user_arn
+  })
+  filename        = "${path.module}/.generated/data-sets/data-source.json"
+  file_permission = "0600"
+}
+
+resource "null_resource" "quicksight_data_source" {
+  triggers = {
+    checksum = filesha256("${path.module}/data-sets/data-source.json")
+  }
+
+  provisioner "local-exec" {
+    command = join(" ", [
+      "aws quicksight create-data-source",
+      "--cli-input-json file://${local_file.quicksight_data_source.filename}",
+      "--region ${data.aws_region.current.name}",
+      "--aws-account-id ${data.aws_caller_identity.current.account_id}",
+    ])
+  }
+}
+
+resource "local_file" "quicksight_data_sets" {
+  for_each = local.quicksight_dataset_template_paths
+
+  content = templatefile("${path.module}/${each.key}", {
+    region                = data.aws_region.current.name
+    account               = data.aws_caller_identity.current.account_id
+    athena_database_name  = aws_glue_catalog_database.cur.name
+    athena_cur_table_name = var.glue_destination_table
+    user_arn              = var.quicksight_user_arn
+  })
+  filename        = "${path.module}/.generated/${each.key}"
+  file_permission = "0600"
+}
+
+
+resource "null_resource" "quicksight_data_sets" {
+  for_each = local.quicksight_dataset_template_paths
+
+  triggers = {
+    checksum = filesha256(each.key)
+  }
+
+  provisioner "local-exec" {
+    command = join(" ", [
+      "aws quicksight create-data-set",
+      "--cli-input-json file://${local_file.quicksight_data_sets[each.key].filename}",
+      "--region ${data.aws_region.current.name}",
+      "--aws-account-id ${data.aws_caller_identity.current.account_id}",
+    ])
+  }
+}
+
+resource "local_file" "cudos_dashboard" {
+  content = templatefile("${path.module}/dashboards/cudos.json", {
+    region           = data.aws_region.current.name
+    awsAccountId     = data.aws_caller_identity.current.account_id
+    sourceAccountId  = var.quicksight_dashboard_source_account_id
+    dashboardId      = var.quicksight_cudos_dashboard_id
+    sourceTemplateId = var.quicksight_dashboard_cudos_source_template_id
+    user_arn         = var.quicksight_user_arn
+  })
+
+  filename        = "${path.module}/.generated/dashboards/cudos.json"
+  file_permission = "0600"
+}
+
+resource "null_resource" "quicksight_dashboard_cudos" {
+  triggers = {
+    checksum = filesha256("${path.module}/dashboards/cudos.json")
+  }
+
+  provisioner "local-exec" {
+    command = join(" ", [
+      "aws quicksight create-dashboard",
+      "--cli-input-json file://${local_file.cudos_dashboard.filename}",
+      "--region ${data.aws_region.current.name}",
+      "--aws-account-id ${data.aws_caller_identity.current.account_id}",
+      "--output table",
+    ])
+  }
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,11 @@ variable "lambda_log_group_retention_days" {
   default     = 14
 }
 
+variable "glue_destination_table" {
+  description = "Name of the Glue Table to store crawled data and update schema in. Currently, this has to be guessed based on Glue Crawler naming conventions, which results in the table being created by the Crawler automatically. In a later version, this module will create the table and reference it directly by its name."
+  type        = string
+}
+
 variable "glue_crawler_create_log_group" {
   description = "Whether to create a CloudWatch Log Group for the Glue Crawler. Crawlers share Log Group, and this gives the option of managing the Log Group with retention through this module."
   type        = bool
@@ -83,6 +88,29 @@ variable "glue_crawler_log_group_retention_days" {
   description = "Number of days to retain logs from the Glue Crawler, which populates the Athena table whenever new CUR data is available."
   type        = number
   default     = 14
+}
+
+variable "quicksight_cudos_dashboard_id" {
+  description = "ID which will be given to the deployed CUDOS dashboard. Used for internal reference when describing or updating the dashboard."
+  type        = string
+  default     = "cudos"
+}
+
+variable "quicksight_user_arn" {
+  description = "Principal ARN to stich onto the data sets and dashboards. Not sure why this is needed but suspect the principal will be the owner of the provisioned QuickSight resources."
+  type        = string
+}
+
+variable "quicksight_dashboard_source_account_id" {
+  description = "Account ID from which the dashboard templates will be fetched from. The default value is the AWS account documented in https://cudos.workshop.aws/workshop.html"
+  type        = string
+  default     = "223485597511"
+}
+
+variable "quicksight_dashboard_cudos_source_template_id" {
+  description = "Dashboard template ID from which the CUDOS dashboard template will be fetched from. The default value is the identifier documented in https://cudos.workshop.aws/workshop.html"
+  type        = string
+  default     = "cudos_dashboard_v3"
 }
 
 variable "tags" {

--- a/views/account_map.sql
+++ b/views/account_map.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW account_map AS 
+SELECT DISTINCT
+  "line_item_usage_account_id" "account_id"
+, "line_item_usage_account_id" "account_name"
+FROM
+  ${athena_cur_table_name}
+

--- a/views/compute_savings_plan_eligible_spend_sp_ri.sql
+++ b/views/compute_savings_plan_eligible_spend_sp_ri.sql
@@ -1,0 +1,24 @@
+ CREATE OR REPLACE VIEW "compute_savings_plan_eligible_spend" AS
+ SELECT DISTINCT
+ "year"
+ , "month"
+ , "bill_payer_account_id" "payer_account_id"
+ , "line_item_usage_account_id" "linked_account_id"
+ , "bill_billing_period_start_date" "billing_period"
+ , "date_trunc"('hour', "line_item_usage_start_date") "usage_date"
+ , "sum"(CASE
+     WHEN (((("line_item_line_item_type" = 'Usage') AND (NOT ("line_item_usage_type" LIKE '%Spot%'))) AND ("product_servicecode" <> 'AWSDataTransfer')) AND ("line_item_usage_type" NOT LIKE '%DataXfer%')) THEN
+         CASE
+             WHEN (("line_item_product_code" = 'AmazonEC2') AND ("line_item_operation" LIKE '%RunInstances%')) THEN "line_item_unblended_cost"
+             WHEN (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-Provisioned-GB-Second%')) THEN "line_item_unblended_cost"
+             WHEN (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-GB-Second%')) THEN "line_item_unblended_cost"
+             WHEN (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-Provisioned-Concurrency%')) THEN "line_item_unblended_cost"
+             WHEN ("line_item_usage_type" LIKE '%Fargate%') THEN "line_item_unblended_cost"
+             ELSE 0
+         END
+     ELSE 0
+     END) "unblended_cost"
+ FROM
+    ${athena_cur_table_name}
+ WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '1' MONTH)) AND ("line_item_usage_start_date" < ("date_trunc"('day', current_timestamp) - INTERVAL  '1' DAY)) AND ((("line_item_product_code" = 'AmazonEC2') AND ("line_item_operation" LIKE '%RunInstances%')) OR (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-Provisioned-GB-Second%')) OR (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-GB-Second%')) OR (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-Provisioned-Concurrency%')) OR ("line_item_usage_type" LIKE '%Fargate%')) AND ("line_item_line_item_type" = 'Usage') AND ("line_item_usage_type" NOT LIKE '%Spot%') AND ("product_servicecode" <> 'AWSDataTransfer') AND ("line_item_usage_type" NOT LIKE '%DataXfer%'))
+ GROUP BY 1, 2, 3, 4,5,6

--- a/views/compute_savings_plan_eligible_spend_sp_ri.sql
+++ b/views/compute_savings_plan_eligible_spend_sp_ri.sql
@@ -22,3 +22,4 @@
     ${athena_cur_table_name}
  WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '1' MONTH)) AND ("line_item_usage_start_date" < ("date_trunc"('day', current_timestamp) - INTERVAL  '1' DAY)) AND ((("line_item_product_code" = 'AmazonEC2') AND ("line_item_operation" LIKE '%RunInstances%')) OR (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-Provisioned-GB-Second%')) OR (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-GB-Second%')) OR (("line_item_product_code" = 'AWSLambda') AND ("line_item_usage_type" LIKE '%Lambda-Provisioned-Concurrency%')) OR ("line_item_usage_type" LIKE '%Fargate%')) AND ("line_item_line_item_type" = 'Usage') AND ("line_item_usage_type" NOT LIKE '%Spot%') AND ("product_servicecode" <> 'AWSDataTransfer') AND ("line_item_usage_type" NOT LIKE '%DataXfer%'))
  GROUP BY 1, 2, 3, 4,5,6
+

--- a/views/ec2_running_cost_sp_ri.sql
+++ b/views/ec2_running_cost_sp_ri.sql
@@ -1,0 +1,19 @@
+ CREATE OR REPLACE VIEW "ec2_running_cost" AS
+ SELECT DISTINCT
+ "year"
+ , "month"
+ , "bill_billing_period_start_date" "billing_period"
+ ,  "date_trunc"('hour', "line_item_usage_start_date") "usage_date"
+ , "bill_payer_account_id" "payer_account_id"
+ , "line_item_usage_account_id" "linked_account_id"
+ , (CASE WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN 'SavingsPlan' WHEN ("reservation_reservation_a_r_n" <> '') THEN 'Reserved' WHEN ("line_item_usage_type" LIKE '%Spot%') THEN 'Spot' ELSE 'OnDemand' END) "purchase_option"
+ , "sum"(CASE
+     WHEN "line_item_line_item_type" = 'SavingsPlanCoveredUsage' THEN "savings_plan_savings_plan_effective_cost"
+     WHEN "line_item_line_item_type" = 'DiscountedUsage' THEN "reservation_effective_cost"
+     WHEN "line_item_line_item_type" = 'Usage' THEN "line_item_unblended_cost"
+     ELSE 0 END) "amortized_cost"
+ , "round"("sum"("line_item_usage_amount"), 2) "usage_quantity"
+ FROM
+${athena_cur_table_name}
+ WHERE (((((("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '1' MONTH)) AND ("line_item_product_code" = 'AmazonEC2')) AND ("product_servicecode" <> 'AWSDataTransfer')) AND ("line_item_operation" LIKE '%RunInstances%')) AND ("line_item_usage_type" NOT LIKE '%DataXfer%')) AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage')))
+ GROUP BY 1, 2, 3, 4,5,6,7

--- a/views/ec2_running_cost_sp_ri.sql
+++ b/views/ec2_running_cost_sp_ri.sql
@@ -17,3 +17,4 @@
 ${athena_cur_table_name}
  WHERE (((((("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '1' MONTH)) AND ("line_item_product_code" = 'AmazonEC2')) AND ("product_servicecode" <> 'AWSDataTransfer')) AND ("line_item_operation" LIKE '%RunInstances%')) AND ("line_item_usage_type" NOT LIKE '%DataXfer%')) AND ((("line_item_line_item_type" = 'Usage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage')) OR ("line_item_line_item_type" = 'DiscountedUsage')))
  GROUP BY 1, 2, 3, 4,5,6,7
+

--- a/views/ri_sp_mapping_sp_ri.sql
+++ b/views/ri_sp_mapping_sp_ri.sql
@@ -1,0 +1,47 @@
+ CREATE OR REPLACE VIEW "ri_sp_mapping" AS
+ SELECT DISTINCT
+   "a"."billing_period_mapping"
+ , "a"."payer_account_id_mapping"
+ , "a"."ri_sp_arn_mapping"
+ , "a"."ri_sp_end_date"
+ , "b"."ri_sp_term"
+ , "b"."ri_sp_offering"
+ , "b"."ri_sp_payment"
+
+ FROM
+   ((
+    SELECT DISTINCT
+  "bill_billing_period_start_date" "billing_period_mapping"
+ , "bill_payer_account_id" "payer_account_id_mapping"
+ , CASE
+     WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN "savings_plan_savings_plan_a_r_n"
+     WHEN ("reservation_reservation_a_r_n" <> '') THEN "reservation_reservation_a_r_n"ELSE '' END "ri_sp_arn_mapping"
+ , CASE
+     WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN CAST(from_iso8601_timestamp("savings_plan_end_time") AS timestamp)
+     WHEN ("reservation_reservation_a_r_n" <> '' AND "reservation_end_time" <> '') THEN CAST(from_iso8601_timestamp("reservation_end_time") AS timestamp) ELSE NULL END "ri_sp_end_date"
+    FROM
+      ${athena_cur_table_name}
+    WHERE (("line_item_line_item_type" = 'RIFee') OR ("line_item_line_item_type" = 'SavingsPlanRecurringFee'))
+
+ )  a
+ LEFT JOIN (
+    SELECT DISTINCT
+  "bill_billing_period_start_date" "billing_period_mapping"
+ , "bill_payer_account_id" "payer_account_id_mapping"
+ , CASE
+     WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN "savings_plan_savings_plan_a_r_n"
+     WHEN ("reservation_reservation_a_r_n" <> '') THEN "reservation_reservation_a_r_n"ELSE '' END "ri_sp_arn_mapping"
+ , CASE
+     WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN "savings_plan_purchase_term"
+ WHEN ("reservation_reservation_a_r_n" <> '') THEN "pricing_lease_contract_length"ELSE '' END "ri_sp_term"
+ , CASE
+     WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN "savings_plan_offering_type"
+     WHEN ("reservation_reservation_a_r_n" <> '') THEN "pricing_offering_class" ELSE '' END "ri_sp_offering"
+ , CASE
+     WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN "savings_plan_payment_option"
+     WHEN ("reservation_reservation_a_r_n" <> '') THEN "pricing_purchase_option"	ELSE '' END "ri_sp_Payment"
+    FROM
+      ${athena_cur_table_name}
+    WHERE (("line_item_line_item_type" = 'DiscountedUsage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage'))
+
+ )  b ON (("a"."ri_sp_arn_mapping" = "b"."ri_sp_arn_mapping") AND ("a"."billing_period_mapping" = "b"."billing_period_mapping") AND ("a"."payer_account_id_mapping" = "b"."payer_account_id_mapping")))

--- a/views/ri_sp_mapping_sp_ri.sql
+++ b/views/ri_sp_mapping_sp_ri.sql
@@ -45,3 +45,4 @@
     WHERE (("line_item_line_item_type" = 'DiscountedUsage') OR ("line_item_line_item_type" = 'SavingsPlanCoveredUsage'))
 
  )  b ON (("a"."ri_sp_arn_mapping" = "b"."ri_sp_arn_mapping") AND ("a"."billing_period_mapping" = "b"."billing_period_mapping") AND ("a"."payer_account_id_mapping" = "b"."payer_account_id_mapping")))
+

--- a/views/s3_sp_ri.sql
+++ b/views/s3_sp_ri.sql
@@ -1,0 +1,24 @@
+ CREATE OR REPLACE VIEW "s3_view" AS 
+ SELECT DISTINCT
+ "year"
+ , "month"
+ , "bill_billing_period_start_date" "billing_period"
+ , "date_trunc"('day', "line_item_usage_start_date") "usage_date"
+ , "bill_payer_account_id" "payer_account_id"
+ , "line_item_usage_account_id" "linked_account_id"
+ , "line_item_resource_id" "resource_id"
+ , "line_item_product_code" "product_code"
+ , "line_item_operation" "operation"
+ , "product_region" "region"
+ , "line_item_line_item_type" "charge_type"
+ , "pricing_unit" "pricing_unit"
+ , "sum"(CASE
+     WHEN ("line_item_line_item_type" = 'Usage') THEN "line_item_usage_amount"
+     ELSE 0
+     END) "usage_quantity"
+ , "sum"("line_item_unblended_cost") "unblended_cost"
+ , "sum"("pricing_public_on_demand_cost") "public_cost"
+ FROM
+ ${athena_cur_table_name}
+ WHERE (((("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '3' MONTH)) AND ("line_item_usage_start_date" < ("date_trunc"('day', current_timestamp) - INTERVAL  '1' DAY))) AND ("line_item_operation" LIKE '%Storage%')) AND (("line_item_product_code" LIKE '%AmazonGlacier%') OR ("line_item_product_code" LIKE '%AmazonS3%')))
+ GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12

--- a/views/s3_sp_ri.sql
+++ b/views/s3_sp_ri.sql
@@ -22,3 +22,4 @@
  ${athena_cur_table_name}
  WHERE (((("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '3' MONTH)) AND ("line_item_usage_start_date" < ("date_trunc"('day', current_timestamp) - INTERVAL  '1' DAY))) AND ("line_item_operation" LIKE '%Storage%')) AND (("line_item_product_code" LIKE '%AmazonGlacier%') OR ("line_item_product_code" LIKE '%AmazonS3%')))
  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12
+

--- a/views/summary_view_sp_ri.sql
+++ b/views/summary_view_sp_ri.sql
@@ -1,0 +1,77 @@
+  CREATE OR REPLACE VIEW summary_view AS
+  SELECT
+  "year"
+  , "month"
+  ,  "bill_billing_period_start_date" "billing_period"
+  , "date_trunc"('day', "line_item_usage_start_date") "usage_date"
+  , "bill_payer_account_id" "payer_account_id"
+  , "line_item_usage_account_id" "linked_account_id"
+  , "bill_invoice_id" "invoice_id"
+  , "line_item_line_item_type" "charge_type"
+  , CASE
+      WHEN ("line_item_line_item_type" = 'DiscountedUsage') THEN 'Running_Usage'
+      WHEN ("line_item_line_item_type" = 'SavingsPlanCoveredUsage') THEN 'Running_Usage'
+      WHEN ("line_item_line_item_type" = 'Usage') THEN 'Running_Usage' ELSE 'non_usage' END "charge_category"
+  , CASE
+      WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN 'SavingsPlan'
+      WHEN ("reservation_reservation_a_r_n" <> '') THEN 'Reserved'
+      WHEN ("line_item_usage_type" LIKE '%Spot%') THEN 'Spot'
+      ELSE 'OnDemand' END "purchase_option"
+  , CASE
+      WHEN ("savings_plan_savings_plan_a_r_n" <> '') THEN "savings_plan_savings_plan_a_r_n"
+      WHEN ("reservation_reservation_a_r_n" <> '') THEN "reservation_reservation_a_r_n" ELSE '' END "ri_sp_arn"
+  , "line_item_product_code" "product_code"
+  , "product_product_name" "product_name"
+  , CASE
+      WHEN ("bill_billing_entity" = 'AWS Marketplace' AND "line_item_line_item_type" NOT LIKE '%Discount%') THEN "Product_Product_Name"
+      WHEN ("product_servicecode" = '') THEN "line_item_product_code" ELSE "product_servicecode" END "service"
+  , "product_product_family" "product_family"
+  , "line_item_usage_type" "usage_type"
+  , "line_item_operation" "operation"
+  , "line_item_line_item_description" "item_description"
+  , "line_item_availability_zone" "availability_zone"
+  , "product_region" "region"
+  , CASE
+      WHEN (("line_item_usage_type" LIKE '%Spot%') AND ("line_item_product_code" = 'AmazonEC2') AND ("line_item_line_item_type" = 'Usage')) THEN "split_part"("line_item_line_item_description", '.', 1) ELSE "product_instance_type_family" END "instance_type_family"
+  , CASE
+  WHEN (("line_item_usage_type" LIKE '%Spot%') AND ("line_item_product_code" = 'AmazonEC2') AND ("line_item_line_item_type" = 'Usage')) THEN "split_part"("line_item_line_item_description", ' ', 1) ELSE "product_instance_type" END "instance_type"
+  , CASE
+  WHEN (("line_item_usage_type" LIKE '%Spot%') AND ("line_item_product_code" = 'AmazonEC2') AND ("line_item_line_item_type" = 'Usage')) THEN "split_part"("split_part"("line_item_line_item_description", ' ', 2), '/', 1) ELSE "product_operating_system" END "platform"
+  , "product_tenancy" "tenancy"
+  , "product_physical_processor" "processor"
+  , "product_processor_features" "processor_features"
+  , "product_database_engine" "database_engine"
+  , "product_group" "product_group"
+  , "product_from_location" "product_from_location"
+  , "product_to_location" "product_to_location"
+  , "product_current_generation" "current_generation"
+  , "line_item_legal_entity" "legal_entity"
+  , "bill_billing_entity" "billing_entity"
+  , "pricing_unit" "pricing_unit"
+  , approx_distinct("Line_item_resource_id") "resource_id_count"
+  , sum(CASE
+  WHEN ("line_item_line_item_type" = 'SavingsPlanCoveredUsage') THEN "line_item_usage_amount"
+  WHEN ("line_item_line_item_type" = 'DiscountedUsage') THEN "line_item_usage_amount"
+  WHEN ("line_item_line_item_type" = 'Usage') THEN "line_item_usage_amount" ELSE 0 END) "usage_quantity"
+  , sum ("line_item_unblended_cost") "unblended_cost"
+  , sum(CASE
+      WHEN ("line_item_line_item_type" = 'SavingsPlanCoveredUsage') THEN "savings_plan_savings_plan_effective_cost"
+      WHEN ("line_item_line_item_type" = 'SavingsPlanRecurringFee') THEN ("savings_plan_total_commitment_to_date" - "savings_plan_used_commitment")
+      WHEN ("line_item_line_item_type" = 'SavingsPlanNegation') THEN 0
+      WHEN ("line_item_line_item_type" = 'SavingsPlanUpfrontFee') THEN 0
+      WHEN ("line_item_line_item_type" = 'DiscountedUsage') THEN "reservation_effective_cost"
+      WHEN ("line_item_line_item_type" = 'RIFee') THEN ("reservation_unused_amortized_upfront_fee_for_billing_period" + "reservation_unused_recurring_fee")
+      WHEN (("line_item_line_item_type" = 'Fee') AND ("reservation_reservation_a_r_n" <> '')) THEN 0 ELSE "line_item_unblended_cost" END) "amortized_cost"
+  , sum(CASE
+      WHEN ("line_item_line_item_type" = 'SavingsPlanRecurringFee') THEN (-"savings_plan_amortized_upfront_commitment_for_billing_period")
+      WHEN ("line_item_line_item_type" = 'RIFee') THEN (-"reservation_amortized_upfront_fee_for_billing_period") ELSE 0 END) "ri_sp_trueup"
+  , sum(CASE
+      WHEN ("line_item_line_item_type" = 'SavingsPlanUpfrontFee') THEN "line_item_unblended_cost"
+      WHEN (("line_item_line_item_type" = 'Fee') AND ("reservation_reservation_a_r_n" <> '')) THEN "line_item_unblended_cost"ELSE 0 END) "ri_sp_upfront_fees"
+  , sum(CASE
+      WHEN ("line_item_line_item_type" <> 'SavingsPlanNegation') THEN "pricing_public_on_demand_cost" ELSE 0 END) "public_cost"
+  FROM
+  ${athena_cur_table_name}
+  WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH)))
+
+  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34

--- a/views/summary_view_sp_ri.sql
+++ b/views/summary_view_sp_ri.sql
@@ -75,3 +75,4 @@
   WHERE (("bill_billing_period_start_date" >= ("date_trunc"('month', current_timestamp) - INTERVAL  '7' MONTH)) AND (CAST("concat"("year", '-', "month", '-01') AS date) >= ("date_trunc"('month', current_date) - INTERVAL  '7' MONTH)))
 
   GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34
+


### PR DESCRIPTION
There's _a lot_ of `local-exec` provisioner magic happening to make up for lack of QuickSight support in the AWS Terraform provider.

- [x] Triggers for detecting updated data sets and dashboards
- [ ] UPSERT-like behavior for QuickSight resources

Closes #16 and #17