### PR TITLE
improvement: tighten IAM for Crawler

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install pre-commit & deps
       run: |
         pip install pre-commit
-        curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
+        curl -L "$(curl -Ls https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64" | head -n1)" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
 
     - name: Run pre-commit
       run: pre-commit run --color=always --show-diff-on-failure --all-files

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}

--- a/notifications.tf
+++ b/notifications.tf
@@ -2,8 +2,6 @@ locals {
   lambda_function_name = "${var.report_name}-crawler-trigger"
 }
 
-data "aws_caller_identity" "current" {}
-
 resource "aws_s3_bucket_notification" "cur" {
   bucket = var.s3_bucket_name
 
@@ -93,7 +91,7 @@ data "aws_iam_policy_document" "crawler_trigger" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["*"]
+    resources = ["${aws_cloudwatch_log_group.lambda.arn}:*"]
   }
 
   statement {


### PR DESCRIPTION
First off, we no longer use the AWS managed IAM policy `AWSGlueServiceRole`.
The role policies defined by this module instead contain tighter permissions on the necessary resources.
